### PR TITLE
Replace set-output with $GITHUB_OUTPUT

### DIFF
--- a/docker-sign-push-action/push.sh
+++ b/docker-sign-push-action/push.sh
@@ -11,6 +11,6 @@ docker trust key load "$PATH_KEYS/$SIGNER_KEY_HASH.key"
 docker trust sign "$FULL_IMAGE_NAME"
 docker push "$FULL_IMAGE_NAME"
 DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$FULL_IMAGE_NAME" | sed 's/.*@//g')
-echo "::set-output name=digest::$DIGEST"
+echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 rm "$PATH_KEYS/$SIGNER_KEY_HASH.key"
 docker rmi "$FULL_IMAGE_NAME"


### PR DESCRIPTION
[Starting from June 1](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), the `set-output` command will start to fail as it has been phased out.